### PR TITLE
Feature/#86 release fixes

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -71,6 +71,6 @@ class Repo < ApplicationRecord
   end
 
   def delete_branch(branch)
-    client.delete_branch(remote_url, release_branch_name)
+    client.delete_branch(remote_url, branch)
   end
 end

--- a/app/services/release_manager.rb
+++ b/app/services/release_manager.rb
@@ -10,7 +10,7 @@ class ReleaseManager
 
   def open_pr?
     repo.pull_requests.any? do |pr|
-      pr[:base][:ref] == 'master'
+      pr[:base][:ref] == 'master' && pr[:head][:ref].starts_with?('release/')
     end
   end
 

--- a/app/services/release_manager.rb
+++ b/app/services/release_manager.rb
@@ -9,9 +9,7 @@ class ReleaseManager
   end
 
   def open_pr?
-    repo.pull_requests.any? do |pr|
-      pr[:base][:ref] == 'master' && pr[:head][:ref].starts_with?('release/')
-    end
+    repo.pull_requests.any? { |pr| release_pr?(pr) }
   end
 
   def create_release
@@ -23,7 +21,7 @@ class ReleaseManager
 
   def merge_prs(branch = 'master')
     repo.pull_requests.each do |pr|
-      next unless pr[:base][:ref] == branch
+      next unless release_pr?(pr, base: branch)
       next if pr[:title].include?('CONFLICTS')
       log "Merging PR ##{pr[:number]} - #{pr[:title]}"
 
@@ -39,6 +37,10 @@ class ReleaseManager
   private
 
   attr_reader :board, :repo, :release_branch_name, :merge_conflicts, :remote_pr
+
+  def release_pr?(remote_pr, base: 'master')
+    remote_pr[:base][:ref] == base && remote_pr[:head][:ref].starts_with?('release/')
+  end
 
   def release_pr_name
     if merge_conflicts.any?

--- a/app/services/release_manager.rb
+++ b/app/services/release_manager.rb
@@ -75,8 +75,9 @@ class ReleaseManager
     )
     log 'done'
     true
-  rescue Octokit::UnprocessableEntity
+  rescue Octokit::UnprocessableEntity => error
     log 'Could not create pull request, deleting branch'
+    announce_pr_failed(error)
     repo.delete_branch(release_branch_name)
     false
   end
@@ -183,6 +184,17 @@ class ReleaseManager
         title_link: pr[:html_url],
         text: pr[:body],
         color: 'good'
+      }
+    )
+  end
+
+  def announce_pr_failed(error)
+    slack_notifier.notify(
+      '*Pull Request Failed*',
+      attachments: {
+        title: "#{repo.name}: Failed to create release",
+        text: error.message,
+        color: 'danger'
       }
     )
   end

--- a/spec/services/release_manager_spec.rb
+++ b/spec/services/release_manager_spec.rb
@@ -233,6 +233,8 @@ RSpec.describe ReleaseManager, type: :service do
 
         aggregate_failures do
           expect(branch_deletion_request).to have_been_requested
+
+          expect(slack_notifier).to have_received(:notify).with(/pull request failed/i, a_hash_including(:attachments))
         end
       end
     end

--- a/spec/services/release_manager_spec.rb
+++ b/spec/services/release_manager_spec.rb
@@ -1,31 +1,200 @@
 require 'rails_helper'
+
 RSpec.describe ReleaseManager, type: :service do
+  subject { described_class.new(board, repo) }
+
   describe '#open_pr?' do
-    subject{ ReleaseManager.new(board, repo) }
     let(:repo) { create(:repo) }
-    let(:board) { create(:board, repos: [ repo ]) }
+    let(:board) { create(:board, repos: [repo]) }
+
     before do
       stub_request(
-        :get, "https://api.github.com/repos/user/repo_name/pulls?per_page=100"
+        :get, 'https://api.github.com/repos/user/repo_name/pulls?per_page=100'
       ).to_return(status: 200, body: body, headers: {})
     end
+
     context 'when there are no PRs open to master' do
-      let(:body) { [ ] }
+      let(:body) { [] }
+
       it 'returns false' do
         expect(subject.open_pr?).to be(false)
       end
     end
 
     context 'when there is an open PR to master' do
-      let(:body) {
+      let(:body) do
         [
           base: {
             ref: 'master'
           }
         ]
-      }
+      end
+
       it 'returns true' do
         expect(subject.open_pr?).to be(true)
+      end
+    end
+  end
+
+  describe 'create_release' do
+    include_context 'board with swimlanes'
+
+    let(:deploying) { create(:swimlane, name: 'Deploying', board: board, position: 2) }
+
+    def self.create_ticket(name)
+      let(name) { create(:ticket, repo: repo, remote_title: name) }
+    end
+
+    create_ticket(:unmerged_ticket_1)
+    create_ticket(:unmerged_ticket_2)
+    create_ticket(:merged_ticket)
+    create_ticket(:ticket_without_branch)
+    create_ticket(:non_deploying_ticket)
+    let(:unmerged_tickets) { [unmerged_ticket_1, unmerged_ticket_2] }
+
+    let(:master_sha) { SecureRandom.hex(20) }
+    let(:release_branch_name) { Time.now.strftime('release/%Y%m%d-%H%M%S') }
+
+    def branch_name(ticket)
+      "feature/##{ticket.remote_number}-#{ticket.remote_title.parameterize}"
+    end
+
+    def stub_get(path, status: 200)
+      response = block_given? ? yield.to_json : ''
+
+      stub_request(:get, "https://api.github.com/repos/#{remote_url}/#{path}")
+        .with(query: hash_including({}))
+        .and_return(status: status, headers: { 'Content-Type' => 'application/json' }, body: response)
+    end
+
+    def stub_post(path, body, status: 201)
+      response = block_given? ? yield.to_json : ''
+
+      stub_request(:post, "https://api.github.com/repos/#{remote_url}/#{path}")
+        .with(body: body)
+        .and_return(status: status, headers: { 'Content-Type' => 'application/json' }, body: response)
+    end
+
+    def have_sent_message(title, attachments = a_hash_including(:attachments))
+      have_received(:notify).with(title, attachments)
+    end
+
+    before do
+      board.update_attributes!(deploy_swimlane: deploying, additional_branches_regex: '^configuration_changes$')
+
+      [*unmerged_tickets, merged_ticket, ticket_without_branch].each do |ticket|
+        board.board_tickets.create!(swimlane: deploying, ticket: ticket)
+      end
+
+      board.board_tickets.create!(swimlane: dev, ticket: non_deploying_ticket)
+
+      stub_get('branches') do
+        [
+          { name: 'master' },
+          { name: 'configuration_changes' },
+          *unmerged_tickets.map { |ticket| { name: branch_name(ticket) } },
+          { name: branch_name(non_deploying_ticket) }
+        ]
+      end
+
+      unmerged_tickets.each do |ticket|
+        stub_get("compare/master...#{URI.escape branch_name(ticket)}") do
+          { total_commits: 2 }
+        end
+      end
+
+      stub_get("compare/master...#{URI.escape branch_name(non_deploying_ticket)}") do
+        { total_commits: 2 }
+      end
+
+      stub_get('git/refs/heads/master') { { object: { sha: master_sha } } }
+
+      allow(SlackNotifier).to receive(:new).and_return(slack_notifier)
+    end
+
+    let(:slack_notifier) { double('SlackNotifier', notify: true) }
+
+    let!(:branch_request) do
+      stub_post('git/refs', ref: "refs/heads/#{release_branch_name}", sha: master_sha)
+    end
+
+    around do |example|
+      # Make it easier to match against release branch name
+      Timecop.freeze { example.run }
+    end
+
+    context 'with no conflicts' do
+      let!(:ticket_merge_requests) do
+        unmerged_tickets.map do |ticket|
+          stub_post('merges', hash_including(base: release_branch_name, head: branch_name(ticket)))
+        end
+      end
+
+      let!(:additional_branch_merge_request) do
+        stub_post('merges', hash_including(base: release_branch_name, head: 'configuration_changes'))
+      end
+
+      let!(:pr_request) do
+        stub_post('pulls', hash_including(base: 'master', head: release_branch_name)) do
+          { html_url: "https://github.com/#{remote_url}/pulls/1" }
+        end
+      end
+
+      it 'creates a release' do
+        subject.create_release
+
+        aggregate_failures do
+          expect(branch_request).to have_been_requested
+          expect(ticket_merge_requests).to all have_been_requested
+          expect(additional_branch_merge_request).to have_been_requested
+          expect(pr_request).to have_been_requested
+
+          expect(slack_notifier).to have_sent_message(/pull request created/i)
+        end
+      end
+    end
+
+    context 'with a conflict' do
+      let!(:successful_merge_request) do
+        stub_post('merges', hash_including(base: release_branch_name, head: branch_name(unmerged_ticket_1)))
+      end
+
+      let!(:unsuccessful_merge_request) do
+        stub_post(
+          'merges', hash_including(base: release_branch_name, head: branch_name(unmerged_ticket_2)),
+          status: 409
+        ) { { message: 'Merge Conflict' } }
+      end
+
+      let!(:additional_branch_merge_request) do
+        stub_post('merges', hash_including(base: release_branch_name, head: 'configuration_changes'))
+      end
+
+      let!(:pr_request) do
+        params = hash_including(
+          base: 'master',
+          head: release_branch_name,
+          title: /(CONFLICTS)/i,
+          body: /could not merge all branches/i
+        )
+
+        stub_post('pulls', params) do
+          { html_url: "https://github.com/#{remote_url}/pulls/1" }
+        end
+      end
+
+      it 'creates a release with notice about conflicts' do
+        subject.create_release
+
+        aggregate_failures do
+          expect(branch_request).to have_been_requested
+          expect(successful_merge_request).to have_been_requested
+          expect(unsuccessful_merge_request).to have_been_requested
+          expect(additional_branch_merge_request).to have_been_requested
+          expect(pr_request).to have_been_requested
+
+          expect(slack_notifier).to have_sent_message(/pull request created/i)
+        end
       end
     end
   end

--- a/spec/support/github_api_stub_helper.rb
+++ b/spec/support/github_api_stub_helper.rb
@@ -9,8 +9,17 @@ module GitHubApiStubHelper
       .with(body: body)
   end
 
+  def stub_gh_put(path, body = hash_including({}), status: 200, &block)
+    stub_gh_request(:put, path, status: status, &block)
+      .with(body: body)
+  end
+
   def stub_gh_delete(path, status: 204, &block)
     stub_gh_request(:delete, path, status: status, &block)
+  end
+
+  def expand_gh_url(path)
+    "https://api.github.com/repos/#{remote_url}/#{path}"
   end
 
   private
@@ -18,8 +27,14 @@ module GitHubApiStubHelper
   def stub_gh_request(verb, path, status:)
     response = block_given? ? yield.to_json : ''
 
-    stub_request(verb, "https://api.github.com/repos/#{remote_url}/#{path}")
-      .and_return(status: status, headers: { 'Content-Type' => 'application/json' }, body: response)
+    url = expand_gh_url(path)
+    url = Addressable::Template.new(url) if url.include?('{')
+
+    stub_request(verb, url).and_return(
+      status: status,
+      headers: { 'Content-Type' => 'application/json' },
+      body: response
+    )
   end
 end
 

--- a/spec/support/github_api_stub_helper.rb
+++ b/spec/support/github_api_stub_helper.rb
@@ -1,0 +1,28 @@
+module GitHubApiStubHelper
+  def stub_gh_get(path, status: 200, &block)
+    stub_gh_request(:get, path, status: status, &block)
+      .with(query: hash_including({}))
+  end
+
+  def stub_gh_post(path, body, status: 201, &block)
+    stub_gh_request(:post, path, status: status, &block)
+      .with(body: body)
+  end
+
+  def stub_gh_delete(path, status: 204, &block)
+    stub_gh_request(:delete, path, status: status, &block)
+  end
+
+  private
+
+  def stub_gh_request(verb, path, status:)
+    response = block_given? ? yield.to_json : ''
+
+    stub_request(verb, "https://api.github.com/repos/#{remote_url}/#{path}")
+      .and_return(status: status, headers: { 'Content-Type' => 'application/json' }, body: response)
+  end
+end
+
+RSpec.configure do |config|
+  config.include GitHubApiStubHelper
+end


### PR DESCRIPTION
Connects #86 
Connects #80 
Connects #77

- Fixes an error that was stopping Flight Plan rolling back releases
- Makes Flight Plan more picky about what it considers a mergeable (release) PR
- Sends a Slack message if we fail to create a release PR
- Doesn't bother trying to create a PR if we know that all the branches have conflicts with `master`